### PR TITLE
Fix gps location

### DIFF
--- a/app/src/main/java/com/example/weatherapp/data/local/WeatherLocalDataSource.kt
+++ b/app/src/main/java/com/example/weatherapp/data/local/WeatherLocalDataSource.kt
@@ -76,4 +76,8 @@ class WeatherLocalDataSource(private val weatherDatabase: WeatherDatabase) {
     fun getCurrentLocationCoords(): Flow<CurrentLocation?> {
         return weatherDatabase.currentLocationDao().getCurrent()
     }
+
+    suspend fun deleteCurrentLocationCoords() {
+        weatherDatabase.currentLocationDao().deleteCurrent()
+    }
 }

--- a/app/src/main/java/com/example/weatherapp/data/local/daos/CurrentLocationDao.kt
+++ b/app/src/main/java/com/example/weatherapp/data/local/daos/CurrentLocationDao.kt
@@ -14,4 +14,7 @@ interface CurrentLocationDao {
 
     @Query("SELECT * FROM current_location")
     fun getCurrent(): Flow<CurrentLocation?>
+
+    @Query("DELETE  FROM current_location")
+    suspend fun deleteCurrent()
 }

--- a/app/src/main/java/com/example/weatherapp/di/InteractorsModule.kt
+++ b/app/src/main/java/com/example/weatherapp/di/InteractorsModule.kt
@@ -77,4 +77,9 @@ class InteractorsModule {
     @Singleton
     fun providesGetLatestCityName(repository: Repository): GetCurrentLocation =
         GetCurrentLocation(repository)
+
+    @Provides
+    @Singleton
+    fun providesDeleteCurrentLocation(repository: Repository): DeleteCurrentLocation =
+        DeleteCurrentLocation(repository)
 }

--- a/app/src/main/java/com/example/weatherapp/interactors/localcalls/locations/DeleteCurrentLocation.kt
+++ b/app/src/main/java/com/example/weatherapp/interactors/localcalls/locations/DeleteCurrentLocation.kt
@@ -1,0 +1,11 @@
+package com.example.weatherapp.interactors.localcalls.locations
+
+import com.example.weatherapp.repository.Repository
+
+class DeleteCurrentLocation(
+    private val repository: Repository,
+) {
+    suspend fun deleteCurrentLocation() {
+        repository.deleteCurrentLocationCoords()
+    }
+}

--- a/app/src/main/java/com/example/weatherapp/repository/Repository.kt
+++ b/app/src/main/java/com/example/weatherapp/repository/Repository.kt
@@ -78,8 +78,12 @@ class Repository(
     ): Flow<Result<Unit>> {
         return currentCoordWeatherResponse.flowOfResult(
             {
-                weatherLocalDataSource.insertCurrentLocationCoords(CurrentLocation(it.name, it.lat,
-                    it.lon))
+                weatherLocalDataSource.insertCurrentLocationCoords(
+                    CurrentLocation(
+                        it.name, it.lat,
+                        it.lon
+                    )
+                )
                 Success(Unit)
             },
             {
@@ -161,6 +165,10 @@ class Repository(
     //Current Location
     fun getCurrentLocationCoords(): Flow<CurrentLocation?> {
         return weatherLocalDataSource.getCurrentLocationCoords()
+    }
+
+    suspend fun deleteCurrentLocationCoords() {
+        return weatherLocalDataSource.deleteCurrentLocationCoords()
     }
 
     //Unsaved entries

--- a/app/src/main/java/com/example/weatherapp/ui/coords/GPSFragmentViewModel.kt
+++ b/app/src/main/java/com/example/weatherapp/ui/coords/GPSFragmentViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.viewModelScope
 import com.example.weatherapp.data.remote.checkStatus
 import com.example.weatherapp.interactors.apicalls.GetCurrentCoordWeather
 import com.example.weatherapp.interactors.localcalls.citynames.GetCurrentLocation
+import com.example.weatherapp.interactors.localcalls.locations.DeleteCurrentLocation
 import com.example.weatherapp.ui.utils.ObservableViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -17,6 +18,7 @@ import javax.inject.Inject
 class GPSFragmentViewModel @Inject constructor(
     private val getCurrentCoordWeather: GetCurrentCoordWeather,
     private val getCurrentLocation: GetCurrentLocation,
+    private val deleteCurrentLocation: DeleteCurrentLocation
 ) : ObservableViewModel() {
 
     private val _locationName = MutableSharedFlow<String>()
@@ -28,6 +30,9 @@ class GPSFragmentViewModel @Inject constructor(
         get() = _errorMessage.asSharedFlow()
 
     fun setUpData(lat: Double?, lon: Double?) {
+        viewModelScope.launch {
+            deleteCurrentLocation.deleteCurrentLocation()
+        }
         getWeatherData(lat, lon)
         getCoordsDataFromDatabase()
     }


### PR DESCRIPTION
As weather for gps always was loaded for a single location, delete functionality is provided that erases the table with current locations from the DB every time the current location button is pressed.